### PR TITLE
Fix Tailwind hidden/flex conflict in 3D layout sidebar

### DIFF
--- a/factory-ui/src/pages/Department3DLayoutPage.jsx
+++ b/factory-ui/src/pages/Department3DLayoutPage.jsx
@@ -1528,7 +1528,6 @@ export default function Department3DLayoutPage() {
                     Show labels
                   </label>
                 </div>
-
                 <div className="flex flex-wrap items-center gap-2">
                   {["RUNNING", "IDLE", "DOWN", "MAINTENANCE", "OFF", "ALL"].map(
                     (s) => (
@@ -1569,7 +1568,6 @@ export default function Department3DLayoutPage() {
                 </div>
               </div>
             ) : null}
-
             <DepartmentFloor3DViewer
               modelUrl={
                 draft?.threeD?.floorModelUrl || "/models/floor-model.glb"

--- a/factory-ui/src/pages/Department3DLayoutPage.jsx
+++ b/factory-ui/src/pages/Department3DLayoutPage.jsx
@@ -688,7 +688,7 @@ export default function Department3DLayoutPage() {
         >
           {isFullscreen ? (
             <div className="absolute left-0 top-0 z-20 flex h-full w-[266px] overflow-hidden border-r bg-white/95">
-              <div className="hidden flex w-14 flex-col items-center gap-2 border-r bg-slate-50/80 py-3">
+              <div className="hidden md:flex w-14 flex-col items-center gap-2 border-r bg-slate-50/80 py-3">
                 <button
                   type="button"
                   className={


### PR DESCRIPTION
Fixes a Tailwind CSS class conflict in the 3D layout sidebar by replacing
`hidden flex` with `hidden md:flex`.

This removes layout warnings and ensures predictable responsive behavior.
